### PR TITLE
Allow Extending classes to override printResultSet

### DIFF
--- a/src/main/java/org/codehaus/mojo/sql/SqlExecMojo.java
+++ b/src/main/java/org/codehaus/mojo/sql/SqlExecMojo.java
@@ -1142,13 +1142,6 @@ public class SqlExecMojo
 
             getLog().debug( updateCountTotal + " rows affected" );
 
-            if ( printResultSet )
-            {
-                StringBuffer line = new StringBuffer();
-                line.append( updateCountTotal ).append( " rows affected" );
-                out.println( line );
-            }
-
             SQLWarning warning = conn.getWarnings();
             while ( warning != null )
             {
@@ -1183,7 +1176,7 @@ public class SqlExecMojo
      * @param out the place to print results
      * @throws SQLException on SQL problems.
      */
-    private void printResultSet( ResultSet rs, PrintStream out )
+    protected void printResultSet( ResultSet rs, PrintStream out )
         throws SQLException
     {
         if ( rs != null )


### PR DESCRIPTION
To allow other plugins to extend this plugin and be able to format the
output differently, needed to change the printResultSet() from private
to protected. Also removed the printing of the rows affected to the
output file as this "corrupts" the output.